### PR TITLE
Add a code example for completing signMessage using MPC.

### DIFF
--- a/demo/mpc_demo/signMessage.ts
+++ b/demo/mpc_demo/signMessage.ts
@@ -17,8 +17,7 @@ const defaults = {
     PRIVATE_KEY_PEM_FILE: '',
     APIKEY_PUBLIC_KEY_PEM_FILE: '',
     BASE_URL: '',
-    ACCOUNT_KEY: '',
-    ACCOUNT_TOKEN_ADDRESS: '',
+    ACCOUNT_KEY: ''
 }
 
 const mpcDemoConfigRC = rc('mpcdemo', defaults)

--- a/demo/mpc_demo/signMessage.ts
+++ b/demo/mpc_demo/signMessage.ts
@@ -1,0 +1,132 @@
+import {SafeheronClient} from '../../src/safeheron';
+import {concat, splitSignature} from '@ethersproject/bytes';
+import {readFileSync} from 'fs';
+import {v4 as uuid} from 'uuid';
+import path from 'path'
+import rc from 'rc';
+import {
+    CreateMPCSignTransactionRequest,
+    MPCSignApi,
+    OneMPCSignTransactionsRequest
+} from "../../src/safeheron/mpcSignApi";
+
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
+
+const defaults = {
+    APIKEY: '',
+    PRIVATE_KEY_PEM_FILE: '',
+    APIKEY_PUBLIC_KEY_PEM_FILE: '',
+    BASE_URL: '',
+    ACCOUNT_KEY: '',
+    ACCOUNT_TOKEN_ADDRESS: '',
+}
+
+const mpcDemoConfigRC = rc('mpcdemo', defaults)
+
+function getConfigValue(key: string) {
+    const value = mpcDemoConfigRC[key];
+    if (!value) {
+        throw new Error(`missing config entry for '${key}'`);
+    }
+    return value;
+}
+
+const apiKey = getConfigValue('APIKEY');
+const apiKeyPublicKey = readFileSync(path.resolve(getConfigValue('APIKEY_PUBLIC_KEY_PEM_FILE')), 'utf8');
+const yourPrivateKey = readFileSync(path.resolve(getConfigValue('PRIVATE_KEY_PEM_FILE')), 'utf8');
+const accountKey = getConfigValue('ACCOUNT_KEY');
+
+const mpcSignApi: MPCSignApi = new MPCSignApi({
+    baseUrl: getConfigValue('BASE_URL'),
+    apiKey,
+    rsaPrivateKey: yourPrivateKey,
+    safeheronRsaPublicKey: apiKeyPublicKey,
+    requestTimeout: 20000
+});
+
+function delay(num: number) {
+    console.log(`wait ${num}ms.`);
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve(1);
+        }, num)
+    })
+};
+
+async function requestMpcSign(mpcSignApi: MPCSignApi, hash: string, accountKey: string): Promise<string> {
+
+    const request: CreateMPCSignTransactionRequest = {
+        customerRefId: uuid(),
+        sourceAccountKey: accountKey,
+        signAlg: 'Secp256k1',
+        dataList: [{
+            // 32-byte hex string without '0x' prefix
+            data: hash.substring(2)
+        }]
+    };
+
+    const txResult = await mpcSignApi.createMPCSignTransactions(request)
+    return txResult.txKey;
+}
+
+async function retrieveSig(mpcSignApi: MPCSignApi, txKey: string): Promise<string> {
+    // wait and get sig from "v1/transactions/mpcsign/one" api
+    const retrieveRequest: OneMPCSignTransactionsRequest = {
+        txKey
+    };
+
+    for (let i = 0; i < 100; i++) {
+        const retrieveResponse = await mpcSignApi.oneMPCSignTransactions(retrieveRequest)
+        console.log(`mpc sign transaction status: ${retrieveResponse.transactionStatus}, sub status: ${retrieveResponse.transactionSubStatus}`);
+        if (retrieveResponse.transactionStatus === 'FAILED' || retrieveResponse.transactionStatus === 'REJECTED') {
+            throw new Error(`mpc sign transaction was FAILED or REJECTED`);
+        }
+
+        if (retrieveResponse.transactionStatus === 'COMPLETED' && retrieveResponse.transactionSubStatus === 'CONFIRMED') {
+            return retrieveResponse.dataList[0].sig;
+        }
+
+        await delay(5000);
+    }
+
+    throw new Error("can't get sig.");
+}
+
+// hash encode
+async function ethSignMessage(){
+    const message = "here is message to be signed"
+    const messagePrefix = "\x19Ethereum Signed Message:\n";
+    const messageByte = toUtf8Bytes(message)
+    const messageHash = keccak256(concat([
+        toUtf8Bytes(messagePrefix),
+        toUtf8Bytes(String(messageByte.length)),
+        messageByte
+    ]));
+    
+    // Sign with safeheron mpc
+    const mpcSignTxKey = await requestMpcSign(mpcSignApi, messageHash, accountKey);
+    console.log(`[ethereum]mpc sign task created, txKey: ${mpcSignTxKey}`);
+    // Get sig
+    const mpcSig = await retrieveSig(mpcSignApi, mpcSignTxKey);
+    console.log(`[ethereum]got mpc sign result, signature: 0x${mpcSig}`);
+}
+
+async function tronSignMessage(){
+    const message = "here is message to be signed"
+    const messagePrefix = '\x19TRON Signed Message:\n';
+    const messageByte = toUtf8Bytes(message)
+    const messageHash = keccak256(concat([
+        toUtf8Bytes(messagePrefix),
+        toUtf8Bytes(String(messageByte.length)),
+        messageByte
+    ]));
+    // Sign with safeheron mpc
+    const mpcSignTxKey = await requestMpcSign(mpcSignApi, messageHash, accountKey);
+    console.log(`[tron]mpc sign task created, txKey: ${mpcSignTxKey}`);
+    // Get sig
+    const mpcSig = await retrieveSig(mpcSignApi, mpcSignTxKey);
+    console.log(`[tron]got mpc sign result, signature: 0x${mpcSig}`);
+}
+
+ethSignMessage();
+tronSignMessage();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@safeheron/api-sdk",
-  "version": "1.0.5",
+  "version": "1.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@safeheron/api-sdk",
-      "version": "1.0.5",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
@@ -1695,9 +1695,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -6127,9 +6127,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -8185,9 +8185,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "tslint": {
       "version": "6.1.3",


### PR DESCRIPTION
Add a code example for completing signMessage using MPC in the `demo/mpc_demo` directory, with the file named `signMessage.ts`.

USAGE：

1. Enter the `demo/mpc_demo` directory.

```shell
$ cd demo/mpc_demo
```

2. Copy `.mpcdemo.dist` file to `.mpcdemorc`

```shell
$ cp .mpcdemo.dist .mpcdemorc
```

3.  Modify `.mpcdemorc` according to the comments
```ini
# your api key
APIKEY=
# path to your private key file, pem encoded
PRIVATE_KEY_PEM_FILE=
# path to Safeheron api public key file, pem encoded
APIKEY_PUBLIC_KEY_PEM_FILE=
# Safeheron api url
BASE_URL=https://api.safeheron.vip
# RequestTimeout (Millisecond), Default: 20000
requestTimeout: 20000
# Wallet Account key
ACCOUNT_KEY=
```

4. Run the test

```shell
$ ts-node signMessage.ts
```