### PR TITLE
add responseV3convert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safeheron/api-sdk",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Javascript & Typescript SDK for Safeheron API",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,10 @@ export interface SafeheronConfig {
 
 
 export interface SafeheronCoSignerConfig {
-  approvalCallbackServicePrivateKey: string;
-  coSignerPubKey: string;
+  approvalCallbackServicePrivateKey?: string;
+  coSignerPubKey?: string;
+  bizPrivKey?: string;
+  apiPubKey?: string;
 }
 
 export interface SafeheronWebHookConfig {

--- a/src/model/BaseModel.ts
+++ b/src/model/BaseModel.ts
@@ -28,7 +28,7 @@ export interface CoSignerCallBack {
   aesType?: string;
 }
 
-export interface CoSignerCallBackV3 {
+export interface CoSignerRequestV3 {
   bizContent: string;
   version: string;
   timestamp: string;

--- a/src/safeheron/coSignerConverter.ts
+++ b/src/safeheron/coSignerConverter.ts
@@ -17,7 +17,9 @@ export class CoSignerConverter {
     constructor(config: SafeheronCoSignerConfig) {
         this.config = config;
         this.aes = new AES();
-        this.rsa = new RSA(config.coSignerPubKey, config.approvalCallbackServicePrivateKey);
+        //Supports both coSignerPubKey and apiPublKey
+        //Supports both approvalCallbackServicePrivateKey and bizPrivKey
+        this.rsa = new RSA(config.coSignerPubKey || config.apiPubKey || "", config.approvalCallbackServicePrivateKey || config.bizPrivKey || "");
     }
 
     // It has been Deprecated,Please use convertCoSignerResponseWithNewCryptoType


### PR DESCRIPTION
Supports request and response handling methods for [Approval Callback Service v3 version](https://docs.safeheron.vip/api/en.html#Callback%20V3). Refer to:  
- `CoSignerConverter.requestV3convert`  
- `CoSignerConverter.responseV3convert`