### PR TITLE
Add riskType, entity, hopNum, and exposureType fields to RiskDetail in AML Risk Assessment Result

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safeheron/api-sdk",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Javascript & Typescript SDK for Safeheron API",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/safeheron/toolsApi.ts
+++ b/src/safeheron/toolsApi.ts
@@ -108,22 +108,31 @@ export interface MistTrack {
 export interface RiskDetail {
     /**
      * Risk type:
-     * Malicious
-     * Suspected Malicious
-     * High Risk
-     * Medium Risk
+     * sanctioned_entity
+     * illicit_activity
+     * mixer
+     * gambling
+     * risk_exchange
+     * bridge
      */
-    type: string;
+     riskType: string;
 
     /**
-     * Risk label
+     * The name of the entity involved in the risk, example: garantex.io
      */
-    label: string;
+     entity: string;
 
     /**
-     * Wallet address
+     * How many hops to the risk entity, greater than or equal to 1
      */
-    address: string;
+     hopNum: string;
+
+    /**
+     * Risk exposure type:
+     * direct
+     * indirect
+     */
+     exposureType: string;
 
     /**
      * Transaction amount (USD)


### PR DESCRIPTION
Added four new fields to `src/safeheron/toolsApi.RiskDetail` in the AML risk assessment result:
* riskType
* entity
* hopNum
* exposureType

These fields provide more context in the risk details and are fully backward-compatible.