### PR TITLE
Added accountKey field to Transaction List V2

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -1,8 +1,8 @@
 name: Release
+
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [ released ]
 
 jobs:
   maybe-release:

--- a/demo/api_demo/transactionDemo.ts
+++ b/demo/api_demo/transactionDemo.ts
@@ -3,7 +3,7 @@ import {v4 as uuid} from 'uuid';
 import {readFileSync} from 'fs';
 import path from 'path'
 import rc from 'rc';
-import {CreateTransactionRequest, TransactionApi} from "../../src/safeheron/transactionApi";
+import {CreateTransactionRequest, ListTransactionsV2Request, TransactionApi} from "../../src/safeheron/transactionApi";
 
 const defaults = {
     APIKEY: '',
@@ -26,8 +26,6 @@ function getConfigValue(key: string) {
 const apiKey = getConfigValue('APIKEY');
 const apiKeyPublicKey = readFileSync(path.resolve(getConfigValue('APIKEY_PUBLIC_KEY_PEM_FILE')), 'utf8');
 const yourPrivateKey = readFileSync(path.resolve(getConfigValue('PRIVATE_KEY_PEM_FILE')), 'utf8');
-const ACCOUNT_KEY = getConfigValue('ACCOUNT_KEY');
-const DESTINATION_ADDRESS = getConfigValue('DESTINATION_ADDRESS');
 
 
 async function main() {
@@ -41,19 +39,16 @@ async function main() {
             requestTimeout: 20000
         });
 
-        const request: CreateTransactionRequest = {
-            sourceAccountKey: ACCOUNT_KEY,
-            sourceAccountType: 'VAULT_ACCOUNT',
-            destinationAccountType: 'ONE_TIME_ADDRESS',
-            destinationAddress: DESTINATION_ADDRESS,
-            coinKey: 'ETH_GOERLI',
-            txAmount: '0.001',
-            txFeeLevel: 'MIDDLE',
-            customerRefId: uuid(),
+
+
+        const request: ListTransactionsV2Request = {
+            accountKey: "account08a2369f59214b1e9099dc6346f694ca",
+            createTimeMin:1756006706000,
+            createTimeMax:1756352306000
         };
 
-        const transactionResult = await transactionApi.createTransactions(request);
-        console.log(`transaction has been created, txKey: ${transactionResult.txKey}`);
+        const transactionResult = await transactionApi.listTransactionsV2(request);
+        console.log(`transaction has been created, txKey: ${transactionResult}`);
     } catch (e) {
         if (e instanceof SafeheronError) {
             console.error(`failed to create transaction, error code: ${e.code}, message: ${e.message}`);

--- a/demo/api_demo/transactionDemo.ts
+++ b/demo/api_demo/transactionDemo.ts
@@ -3,7 +3,7 @@ import {v4 as uuid} from 'uuid';
 import {readFileSync} from 'fs';
 import path from 'path'
 import rc from 'rc';
-import {CreateTransactionRequest, ListTransactionsV2Request, TransactionApi} from "../../src/safeheron/transactionApi";
+import {CreateTransactionRequest, TransactionApi} from "../../src/safeheron/transactionApi";
 
 const defaults = {
     APIKEY: '',
@@ -26,6 +26,8 @@ function getConfigValue(key: string) {
 const apiKey = getConfigValue('APIKEY');
 const apiKeyPublicKey = readFileSync(path.resolve(getConfigValue('APIKEY_PUBLIC_KEY_PEM_FILE')), 'utf8');
 const yourPrivateKey = readFileSync(path.resolve(getConfigValue('PRIVATE_KEY_PEM_FILE')), 'utf8');
+const ACCOUNT_KEY = getConfigValue('ACCOUNT_KEY');
+const DESTINATION_ADDRESS = getConfigValue('DESTINATION_ADDRESS');
 
 
 async function main() {
@@ -39,16 +41,19 @@ async function main() {
             requestTimeout: 20000
         });
 
-
-
-        const request: ListTransactionsV2Request = {
-            accountKey: "account08a2369f59214b1e9099dc6346f694ca",
-            createTimeMin:1756006706000,
-            createTimeMax:1756352306000
+        const request: CreateTransactionRequest = {
+            sourceAccountKey: ACCOUNT_KEY,
+            sourceAccountType: 'VAULT_ACCOUNT',
+            destinationAccountType: 'ONE_TIME_ADDRESS',
+            destinationAddress: DESTINATION_ADDRESS,
+            coinKey: 'ETH_GOERLI',
+            txAmount: '0.001',
+            txFeeLevel: 'MIDDLE',
+            customerRefId: uuid(),
         };
 
-        const transactionResult = await transactionApi.listTransactionsV2(request);
-        console.log(`transaction has been created, txKey: ${transactionResult}`);
+        const transactionResult = await transactionApi.createTransactions(request);
+        console.log(`transaction has been created, txKey: ${transactionResult.txKey}`);
     } catch (e) {
         if (e instanceof SafeheronError) {
             console.error(`failed to create transaction, error code: ${e.code}, message: ${e.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safeheron/api-sdk",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Javascript & Typescript SDK for Safeheron API",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/safeheron/transactionApi.ts
+++ b/src/safeheron/transactionApi.ts
@@ -282,11 +282,6 @@ export interface TransactionsResponse {
     realDestinationAccountType: string;
 
     /**
-     * Transaction substatus description
-     */
-    transactionSubStatusDesc: string;
-
-    /**
      * Amount in USD when transact
      */
     txAmountToUsd: string;
@@ -296,20 +291,12 @@ export interface TransactionsResponse {
      */
     sourceAccountName: string;
 
-    /**
-     * Source account type name
-     */
-    sourceAccountTypeName: string;
 
     /**
      * Destination account name
      */
     destinationAccountName: string;
 
-    /**
-     * Destination account type name
-     */
-    destinationAccountTypeName: string;
 
     /**
      * Final approver username
@@ -381,6 +368,11 @@ export interface ListTransactionsV2Request extends LimitSearch {
      * Destination account type
      */
     destinationAccountType?: string;
+
+    /**
+     * The unique identifier key of a wallet account, used to query all transactions under that wallet. This is only supported for VAULT_ACCOUNT type wallets. This has a higher priority than sourceAccountKey, sourceAccountType, destinationAccountKey, destinationAccountType, and realDestinationAccountType. If accountKey is passed along with the five parameters mentioned above, only accountKey will be effective
+     */
+    accountKey?: string;
 
     /**
      * Start time for creating a transaction, UNIX timestamp (ms)
@@ -977,12 +969,7 @@ export interface OneTransactionsResponse {
     /**
      * Type of actual destination account
      */
-    realDestinationAccountType: string;
-
-    /**
-     * Transaction substatus description
-     */
-    transactionSubStatusDesc: string;
+    realDestinationAccountType: string
 
     /**
      * Amount in USD when transact
@@ -994,20 +981,12 @@ export interface OneTransactionsResponse {
      */
     sourceAccountName: string;
 
-    /**
-     * Source account type name
-     */
-    sourceAccountTypeName: string;
 
     /**
      * Destination account name
      */
     destinationAccountName: string;
 
-    /**
-     * Destination account type name
-     */
-    destinationAccountTypeName: string;
 
     /**
      * Final approver username


### PR DESCRIPTION
Added a new field to `src/safeheron/transactionApi.ListTransactionsV2Request` in the Transaction List V2 request:
* accountKey: This field is used to query all transactions under that wallet are fully backward-compatible.